### PR TITLE
poll: set id on labels

### DIFF
--- a/templates/poll.tmpl
+++ b/templates/poll.tmpl
@@ -42,7 +42,7 @@
       {{ if eq .PollType "simple" }}
         {{ range $i, $option := .Options }}
         <div class="form-check">
-          <input class="form-check-input" type="radio" name="option" value="{{ $option }}" />
+          <input class="form-check-input" type="radio" name="option" id="{{ $option }}" value="{{ $option }}" />
           <label style="font-size: 1.25rem; line-height: 1.25; padding-left: 4px;" class="form-check-label" for="{{ $option }}">{{ $option }}</label>
         </div>
         <br />
@@ -68,6 +68,7 @@
           <input
             type="number"
             name="{{ $option }}"
+            id="{{ $option }}"
             class="form-control"
             style="height: 1.5em;"
             min="0"


### PR DESCRIPTION
This links the `for` attribute on the `<label>` to the `<input>`. This
way, clicking on the `<label>` will focus the `<input>`, which many
users might expect! :)