### PR TITLE
Voter anonymity in the back-end

### DIFF
--- a/database/poll.go
+++ b/database/poll.go
@@ -25,8 +25,8 @@ type Poll struct {
 const POLL_TYPE_SIMPLE = "simple"
 const POLL_TYPE_RANKED = "ranked"
 
-func GetPoll(id string) (*Poll, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func GetPoll(ctx context.Context, id string) (*Poll, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	objId, _ := primitive.ObjectIDFromHex(id)
@@ -38,8 +38,8 @@ func GetPoll(id string) (*Poll, error) {
 	return &poll, nil
 }
 
-func (poll *Poll) Close() error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func (poll *Poll) Close(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	objId, _ := primitive.ObjectIDFromHex(poll.Id)
@@ -52,8 +52,8 @@ func (poll *Poll) Close() error {
 	return nil
 }
 
-func (poll *Poll) Hide() error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func (poll *Poll) Hide(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	objId, _ := primitive.ObjectIDFromHex(poll.Id)
@@ -66,8 +66,8 @@ func (poll *Poll) Hide() error {
 	return nil
 }
 
-func (poll *Poll) Reveal() error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func (poll *Poll) Reveal(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	objId, _ := primitive.ObjectIDFromHex(poll.Id)
@@ -80,8 +80,8 @@ func (poll *Poll) Reveal() error {
 	return nil
 }
 
-func CreatePoll(poll *Poll) (string, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func CreatePoll(ctx context.Context, poll *Poll) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	result, err := Client.Database("vote").Collection("polls").InsertOne(ctx, poll)
@@ -92,8 +92,8 @@ func CreatePoll(poll *Poll) (string, error) {
 	return result.InsertedID.(primitive.ObjectID).Hex(), nil
 }
 
-func GetOpenPolls() ([]*Poll, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func GetOpenPolls(ctx context.Context) ([]*Poll, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	cursor, err := Client.Database("vote").Collection("polls").Find(ctx, map[string]interface{}{"open": true})
@@ -108,8 +108,8 @@ func GetOpenPolls() ([]*Poll, error) {
 	return polls, nil
 }
 
-func GetClosedOwnedPolls(userId string) ([]*Poll, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func GetClosedOwnedPolls(ctx context.Context, userId string) ([]*Poll, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	cursor, err := Client.Database("vote").Collection("polls").Find(ctx, map[string]interface{}{"createdBy": userId, "open": false})
@@ -123,8 +123,8 @@ func GetClosedOwnedPolls(userId string) ([]*Poll, error) {
 	return polls, nil
 }
 
-func GetClosedVotedPolls(userId string) ([]*Poll, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func GetClosedVotedPolls(ctx context.Context, userId string) ([]*Poll, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	cursor, err := Client.Database("vote").Collection("votes").Aggregate(ctx, mongo.Pipeline{
@@ -168,8 +168,8 @@ func GetClosedVotedPolls(userId string) ([]*Poll, error) {
 	return polls, nil
 }
 
-func (poll *Poll) GetResult() (map[string]int, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func (poll *Poll) GetResult(ctx context.Context) (map[string]int, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	pollId, _ := primitive.ObjectIDFromHex(poll.Id)

--- a/database/ranked_vote.go
+++ b/database/ranked_vote.go
@@ -13,8 +13,8 @@ type RankedVote struct {
 	Options map[string]int     `bson:"options"`
 }
 
-func CastRankedVote(vote *RankedVote) error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func CastRankedVote(ctx context.Context, vote *RankedVote) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	_, err := Client.Database("vote").Collection("votes").InsertOne(ctx, vote)

--- a/database/ranked_vote.go
+++ b/database/ranked_vote.go
@@ -10,7 +10,6 @@ import (
 type RankedVote struct {
 	Id      string             `bson:"_id,omitempty"`
 	PollId  primitive.ObjectID `bson:"pollId"`
-	UserId  string             `bson:"userId"`
 	Options map[string]int     `bson:"options"`
 }
 

--- a/database/simple_vote.go
+++ b/database/simple_vote.go
@@ -10,7 +10,6 @@ import (
 type SimpleVote struct {
 	Id     string             `bson:"_id,omitempty"`
 	PollId primitive.ObjectID `bson:"pollId"`
-	UserId string             `bson:"userId"`
 	Option string             `bson:"option"`
 }
 

--- a/database/simple_vote.go
+++ b/database/simple_vote.go
@@ -18,8 +18,8 @@ type SimpleResult struct {
 	Count  int    `bson:"count"`
 }
 
-func CastSimpleVote(vote *SimpleVote) error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func CastSimpleVote(ctx context.Context, vote *SimpleVote) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	_, err := Client.Database("vote").Collection("votes").InsertOne(ctx, vote)

--- a/database/vote.go
+++ b/database/vote.go
@@ -7,8 +7,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func HasVoted(pollId, userId string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func HasVoted(ctx context.Context, pollId, userId string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	pId, err := primitive.ObjectIDFromHex(pollId)

--- a/database/vote.go
+++ b/database/vote.go
@@ -16,7 +16,7 @@ func HasVoted(pollId, userId string) (bool, error) {
 		return false, err
 	}
 
-	count, err := Client.Database("vote").Collection("votes").CountDocuments(ctx, map[string]interface{}{"pollId": pId, "userId": userId})
+	count, err := Client.Database("vote").Collection("voters").CountDocuments(ctx, map[string]interface{}{"pollId": pId, "userId": userId})
 	if err != nil {
 		return false, err
 	}

--- a/database/voter.go
+++ b/database/voter.go
@@ -11,8 +11,8 @@ type Voter struct {
 	UserId string   `bson:"userId"`
 }
 
-func RecordVoter(voter *Voter) error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+func RecordVoter(ctx context.Context, voter *Voter) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	if voter.Id == "" {

--- a/database/voter.go
+++ b/database/voter.go
@@ -3,19 +3,21 @@ package database
 import (
 	"context"
 	"time"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Voter struct {
-	Id     string             `bson:"_id,omitempty"`
-	PollId primitive.ObjectID `bson:"pollId"`
-	UserId string             `bson:"userId"`
+	Id     string   `bson:"_id"`
+	PollId string	`bson:"pollId"`
+	UserId string   `bson:"userId"`
 }
 
 func RecordVoter(voter *Voter) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
+
+	if voter.Id == "" {
+		voter.Id = voter.PollId + "_" + voter.UserId
+	}
 
 	_, err := Client.Database("vote").Collection("voters").InsertOne(ctx, voter)
 	if err != nil {

--- a/database/voter.go
+++ b/database/voter.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Voter struct {
+	Id     string             `bson:"_id,omitempty"`
+	PollId primitive.ObjectID `bson:"pollId"`
+	UserId string             `bson:"userId"`
+}
+
+func RecordVoter(voter *Voter) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	_, err := Client.Database("vote").Collection("voters").InsertOne(ctx, voter)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+

--- a/main.go
+++ b/main.go
@@ -234,7 +234,6 @@ func main() {
 			vote := database.SimpleVote{
 				Id:     "",
 				PollId: pId,
-				UserId: claims.UserInfo.Username,
 				Option: c.PostForm("option"),
 			}
 
@@ -251,7 +250,6 @@ func main() {
 			vote := database.RankedVote{
 				Id:      "",
 				PollId:  pId,
-				UserId:  claims.UserInfo.Username,
 				Options: make(map[string]int),
 			}
 			for _, opt := range poll.Options {
@@ -279,6 +277,12 @@ func main() {
 			c.JSON(500, gin.H{"error": "Unknown Poll Type"})
 			return
 		}
+
+		database.RecordVoter(&database.Voter{
+			Id:	"",
+			PollId:	pId,
+			UserId:	claims.UserInfo.Username,
+		})
 
 		if poll, err := database.GetPoll(c.Param("id")); err == nil {
 			if results, err := poll.GetResult(); err == nil {

--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func main() {
 
 		database.RecordVoter(&database.Voter{
 			Id:	"",
-			PollId:	pId,
+			PollId:	poll.Id,
 			UserId:	claims.UserInfo.Username,
 		})
 

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 		// This is intentionally left unprotected
 		// A user may be unable to vote but should still be able to see a list of polls
 
-		polls, err := database.GetOpenPolls()
+		polls, err := database.GetOpenPolls(c)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -54,12 +54,12 @@ func main() {
 			return polls[i].Id > polls[j].Id
 		})
 
-		closedPolls, err := database.GetClosedVotedPolls(claims.UserInfo.Username)
+		closedPolls, err := database.GetClosedVotedPolls(c, claims.UserInfo.Username)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
 		}
-		ownedPolls, err := database.GetClosedOwnedPolls(claims.UserInfo.Username)
+		ownedPolls, err := database.GetClosedOwnedPolls(c, claims.UserInfo.Username)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -139,7 +139,7 @@ func main() {
 			poll.Options = []string{"Pass", "Fail", "Abstain"}
 		}
 
-		pollId, err := database.CreatePoll(poll)
+		pollId, err := database.CreatePoll(c, poll)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -154,7 +154,7 @@ func main() {
 		// This is intentionally left unprotected
 		// We will check if a user can vote and redirect them to results if not later
 
-		poll, err := database.GetPoll(c.Param("id"))
+		poll, err := database.GetPoll(c, c.Param("id"))
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -208,7 +208,7 @@ func main() {
 			return
 		}
 
-		poll, err := database.GetPoll(c.Param("id"))
+		poll, err := database.GetPoll(c, c.Param("id"))
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -284,8 +284,8 @@ func main() {
 			UserId:	claims.UserInfo.Username,
 		})
 
-		if poll, err := database.GetPoll(c.Param("id")); err == nil {
-			if results, err := poll.GetResult(); err == nil {
+		if poll, err := database.GetPoll(c, c.Param("id")); err == nil {
+			if results, err := poll.GetResult(c); err == nil {
 				if bytes, err := json.Marshal(results); err == nil {
 					broker.Notifier <- sse.NotificationEvent{
 						EventName: poll.Id,
@@ -305,7 +305,7 @@ func main() {
 		// This is intentionally left unprotected
 		// A user may be unable to vote but still interested in the results of a poll
 
-		poll, err := database.GetPoll(c.Param("id"))
+		poll, err := database.GetPoll(c, c.Param("id"))
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -316,7 +316,7 @@ func main() {
             return
         }
 
-		results, err := poll.GetResult()
+		results, err := poll.GetResult(c)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -339,7 +339,7 @@ func main() {
         cl, _ := c.Get("cshauth")
         claims := cl.(csh_auth.CSHClaims)
 
-        poll, err := database.GetPoll(c.Param("id"))
+        poll, err := database.GetPoll(c, c.Param("id"))
 
         if err != nil {
             c.JSON(500, gin.H{"error": err.Error()})
@@ -351,7 +351,7 @@ func main() {
             return
         }
 
-        err = poll.Hide()
+        err = poll.Hide(c)
         if err != nil {
             c.JSON(500, gin.H{"error": err.Error()})
             return
@@ -365,7 +365,7 @@ func main() {
         cl, _ := c.Get("cshauth")
         claims := cl.(csh_auth.CSHClaims)
 
-        poll, err := database.GetPoll(c.Param("id"))
+        poll, err := database.GetPoll(c, c.Param("id"))
 
         if err != nil {
             c.JSON(500, gin.H{"error": err.Error()})
@@ -377,7 +377,7 @@ func main() {
             return
         }
 
-        err = poll.Reveal()
+        err = poll.Reveal(c)
         if err != nil {
             c.JSON(500, gin.H{"error": err.Error()})
             return
@@ -392,7 +392,7 @@ func main() {
 		// This is intentionally left unprotected
 		// A user should be able to close their own polls, regardless of if they can vote
 
-		poll, err := database.GetPoll(c.Param("id"))
+		poll, err := database.GetPoll(c, c.Param("id"))
 
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
@@ -404,7 +404,7 @@ func main() {
 			return
 		}
 
-		err = poll.Close()
+		err = poll.Close(c)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func main() {
 			return
 		}
 
-		hasVoted, err := database.HasVoted(poll.Id, claims.UserInfo.Username)
+		hasVoted, err := database.HasVoted(c, poll.Id, claims.UserInfo.Username)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -214,7 +214,7 @@ func main() {
 			return
 		}
 
-		hasVoted, err := database.HasVoted(poll.Id, claims.UserInfo.Username)
+		hasVoted, err := database.HasVoted(c, poll.Id, claims.UserInfo.Username)
 		if err != nil {
 			c.JSON(500, gin.H{"error": err.Error()})
 			return
@@ -245,7 +245,7 @@ func main() {
 				c.JSON(400, gin.H{"error": "Invalid Option"})
 				return
 			}
-			database.CastSimpleVote(&vote)
+			database.CastSimpleVote(c, &vote)
 		} else if poll.VoteType == database.POLL_TYPE_RANKED {
 			vote := database.RankedVote{
 				Id:      "",
@@ -272,13 +272,13 @@ func main() {
 					vote.Options[c.PostForm("writeinOption")] = rank
 				}
 			}
-			database.CastRankedVote(&vote)
+			database.CastRankedVote(c, &vote)
 		} else {
 			c.JSON(500, gin.H{"error": "Unknown Poll Type"})
 			return
 		}
 
-		database.RecordVoter(&database.Voter{
+		database.RecordVoter(c, &database.Voter{
 			Id:	"",
 			PollId:	poll.Id,
 			UserId:	claims.UserInfo.Username,


### PR DESCRIPTION
Currently, member usernames are recorded alongside their votes in the database, which is necessary to prevent that member from casting additional votes on the same poll. These changes make it (generally) impossible to determine which member put forth a given vote, even by examining the database in the back-end. This was achieved by adding another table to the database which tracks the members who have already voted for a given poll, but does not track the vote they cast. This makes it possible to determine if someone has already voted without also being able to determine which specific vote is theirs.

A voter's identity could still _theoretically_ be determined via some edge cases, such as when only a single vote has been cast on a given poll, but that situation is rare enough to be negligible, and overall back-end anonymity has still certainly been improved regardless.

The behavior of the application should not have been affected by these changes in any way. Local testing suggests that everything works as it did before, but I will defer to those who are more familiar with the codebase to determine whether or not I missed anything. I've provided comments on my commits detailing exactly what I changed and why that change was necessary.