### PR TITLE
Made poll titles wrap when necessary

### DIFF
--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -47,7 +47,7 @@
               class="list-group-item list-group-item-action"
               href="/poll/{{ $poll.Id }}"
             >
-              <span style="font-size: 1.1rem">{{
+              <span style="font-size: 1.1rem; white-space: normal; word-wrap: break-word;">{{
                 $poll.ShortDescription
               }}</span>
 

--- a/templates/poll.tmpl
+++ b/templates/poll.tmpl
@@ -26,7 +26,7 @@
     </nav>
 
     <div class="container main p-5">
-      <h2>{{ .ShortDescription }}</h2>
+      <h2 style="white-space: normal; word-wrap: break-word;">{{ .ShortDescription }}</h2>
       {{ if .LongDescription }}
       <h4>{{ .LongDescription | MakeLinks }}</h4>
       {{ end }}

--- a/templates/result.tmpl
+++ b/templates/result.tmpl
@@ -25,7 +25,7 @@
     </nav>
 
     <div class="container main p-5">
-      <h2>{{ .ShortDescription }}</h2>
+      <h2 style="white-space: normal; word-wrap: break-word;">{{ .ShortDescription }}</h2>
       {{ if .LongDescription }}
       <h4>{{ .LongDescription | MakeLinks }}</h4>
       {{ end }}


### PR DESCRIPTION
## What

Makes it so that the title of polls will wrap to new line(s) when necessary

## Why

Currently, poll titles that are longer than the length of the container will just overflow

## Test Plan

Create a poll with an extremely long title, and verify that it wraps on the home page, the voting page, and the results page

## Env Vars

No changes

## Checklist

- [X] Tested all changes locally
