### PR TITLE
Rename short/long description to title and description

### DIFF
--- a/constitutional.go
+++ b/constitutional.go
@@ -106,7 +106,7 @@ func EvaluatePolls() {
 		// check all voters to see if they have voted
 		if poll.AllowedUsers == nil {
 			logging.Logger.WithFields(logrus.Fields{"method": "EvaluatePolls checkQuorum"}).Error(
-				"Users allowed to vote is nil for \"" + poll.ShortDescription + "\" !! This should not happen!!")
+				"Users allowed to vote is nil for \"" + poll.Title + "\" !! This should not happen!!")
 			continue
 		}
 		for _, user := range poll.AllowedUsers {
@@ -128,7 +128,7 @@ func EvaluatePolls() {
 				oidcClient.GetUserInfo(user)
 				_, _, err = slackData.Client.PostMessage(user.SlackUID,
 					slack.MsgOptionText(
-						"Hello, you have not yet voted on \""+poll.ShortDescription+"\". We have not yet hit quorum"+
+						"Hello, you have not yet voted on \""+poll.Title+"\". We have not yet hit quorum"+
 							" and we need YOU :index_pointing_at_the_viewer: to complete your responsibility as a "+
 							"member of house and vote. \n"+pollLink+"\nThank you!", false))
 				if err != nil {
@@ -144,12 +144,12 @@ func EvaluatePolls() {
 		}
 		// we close the poll here
 		err = poll.Close(ctx)
-		fmt.Println("Time reached, closing poll " + poll.ShortDescription)
+		fmt.Println("Time reached, closing poll " + poll.Title)
 		if err != nil {
 			logging.Logger.WithFields(logrus.Fields{"method": "EvaluatePolls close"}).Error(err)
 			continue
 		}
-		announceStr := "The vote \"" + poll.ShortDescription + "\" has closed."
+		announceStr := "The vote \"" + poll.Title + "\" has closed."
 		if !poll.Hidden {
 			announceStr += " Check out the results at " + pollLink
 		} else {

--- a/database/poll.go
+++ b/database/poll.go
@@ -16,18 +16,18 @@ import (
 )
 
 type Poll struct {
-	Id               string    `bson:"_id,omitempty"`
-	CreatedBy        string    `bson:"createdBy"`
-	ShortDescription string    `bson:"shortDescription"`
-	LongDescription  string    `bson:"longDescription"`
-	VoteType         string    `bson:"voteType"`
-	Options          []string  `bson:"options"`
-	OpenedTime       time.Time `bson:"openedTime"`
-	Open             bool      `bson:"open"`
-	Gatekeep         bool      `bson:"gatekeep"`
-	QuorumType       float64   `bson:"quorumType"`
-	AllowedUsers     []string  `bson:"allowedUsers"`
-	AllowWriteIns    bool      `bson:"writeins"`
+	Id            string    `bson:"_id,omitempty"`
+	CreatedBy     string    `bson:"createdBy"`
+	Title         string    `bson:"title"`
+	Description   string    `bson:"description"`
+	VoteType      string    `bson:"voteType"`
+	Options       []string  `bson:"options"`
+	OpenedTime    time.Time `bson:"openedTime"`
+	Open          bool      `bson:"open"`
+	Gatekeep      bool      `bson:"gatekeep"`
+	QuorumType    float64   `bson:"quorumType"`
+	AllowedUsers  []string  `bson:"allowedUsers"`
+	AllowWriteIns bool      `bson:"writeins"`
 
 	// Prevent this poll from having progress displayed
 	// This is important for events like elections where the results shouldn't be visible mid vote

--- a/main.go
+++ b/main.go
@@ -204,17 +204,17 @@ func main() {
 		}
 
 		poll := &database.Poll{
-			Id:               "",
-			CreatedBy:        claims.UserInfo.Username,
-			ShortDescription: c.PostForm("shortDescription"),
-			LongDescription:  c.PostForm("longDescription"),
-			VoteType:         database.POLL_TYPE_SIMPLE,
-			OpenedTime:       time.Now(),
-			Open:             true,
-			QuorumType:       float64(quorum),
-			Gatekeep:         c.PostForm("gatekeep") == "true",
-			AllowWriteIns:    c.PostForm("allowWriteIn") == "true",
-			Hidden:           c.PostForm("hidden") == "true",
+			Id:            "",
+			CreatedBy:     claims.UserInfo.Username,
+			Title:         c.PostForm("title"),
+			Description:   c.PostForm("description"),
+			VoteType:      database.POLL_TYPE_SIMPLE,
+			OpenedTime:    time.Now(),
+			Open:          true,
+			QuorumType:    float64(quorum),
+			Gatekeep:      c.PostForm("gatekeep") == "true",
+			AllowWriteIns: c.PostForm("allowWriteIn") == "true",
+			Hidden:        c.PostForm("hidden") == "true",
 		}
 		if c.PostForm("rankedChoice") == "true" {
 			poll.VoteType = database.POLL_TYPE_RANKED
@@ -286,16 +286,16 @@ func main() {
 		canModify := containsString(claims.UserInfo.Groups, "active_rtp") || containsString(claims.UserInfo.Groups, "eboard") || poll.CreatedBy == claims.UserInfo.Username
 
 		c.HTML(200, "poll.tmpl", gin.H{
-			"Id":               poll.Id,
-			"ShortDescription": poll.ShortDescription,
-			"LongDescription":  poll.LongDescription,
-			"Options":          poll.Options,
-			"PollType":         poll.VoteType,
-			"RankedMax":        fmt.Sprint(len(poll.Options) + writeInAdj),
-			"AllowWriteIns":    poll.AllowWriteIns,
-			"CanModify":        canModify,
-			"Username":         claims.UserInfo.Username,
-			"FullName":         claims.UserInfo.FullName,
+			"Id":            poll.Id,
+			"Title":         poll.Title,
+			"Description":   poll.Description,
+			"Options":       poll.Options,
+			"PollType":      poll.VoteType,
+			"RankedMax":     fmt.Sprint(len(poll.Options) + writeInAdj),
+			"AllowWriteIns": poll.AllowWriteIns,
+			"CanModify":     canModify,
+			"Username":      claims.UserInfo.Username,
+			"FullName":      claims.UserInfo.FullName,
 		})
 	}))
 
@@ -453,8 +453,8 @@ func main() {
 		votesNeededForQuorum := int(poll.QuorumType * float64(len(poll.AllowedUsers)))
 		c.HTML(200, "result.tmpl", gin.H{
 			"Id":                   poll.Id,
-			"ShortDescription":     poll.ShortDescription,
-			"LongDescription":      poll.LongDescription,
+			"Title":                poll.Title,
+			"Description":          poll.Description,
 			"VoteType":             poll.VoteType,
 			"Results":              results,
 			"IsOpen":               poll.Open,

--- a/templates/closed.tmpl
+++ b/templates/closed.tmpl
@@ -35,7 +35,7 @@
               href="/results/{{ $poll.Id }}"
             >
               <span style="font-size: 1.1rem">
-                {{ $poll.ShortDescription }}
+                {{ $poll.Title }}
               </span>
 
               <span

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -19,16 +19,16 @@
           <input
             type="text"
             class="form-control"
-            name="shortDescription"
-            placeholder="Short Description"
+            name="title"
+            placeholder="Poll Title"
           >
         </div>
         <div class="form-group">
           <input
             type="text"
-            name="longDescription"
+            name="description"
             class="form-control"
-            placeholder="Long Description (Optional)"
+            placeholder="Description (Optional)"
           >
         </div>
         <div class="form-group">

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -40,7 +40,7 @@
               href="/poll/{{ $poll.Id }}"
             >
               <span style="font-size: 1.1rem; white-space: normal; word-wrap: break-word;">
-                {{ $poll.ShortDescription }}
+                {{ $poll.Title }}
               </span>
 
               <span

--- a/templates/poll.tmpl
+++ b/templates/poll.tmpl
@@ -18,9 +18,9 @@
     {{ template "nav" . }}
 
     <div class="container main p-5">
-      <h2 style="white-space: normal; word-wrap: break-word;">{{ .ShortDescription }}</h2>
-      {{ if .LongDescription }}
-      <h4>{{ .LongDescription | MakeLinks }}</h4>
+      <h2 style="white-space: normal; word-wrap: break-word;">{{ .Title }}</h2>
+      {{ if .Description }}
+      <h4>{{ .Description | MakeLinks }}</h4>
       {{ end }}
       {{ if eq .PollType "ranked" }}
       <p>This is a Ranked Choice vote. Rank the candidates in order of your preference. 1 is most preferred, and {{ .RankedMax }} is least perferred. You may leave an option blank

--- a/templates/result.tmpl
+++ b/templates/result.tmpl
@@ -50,9 +50,9 @@
         </div>
       {{ end }}
       
-      <h2 style="white-space: normal; word-wrap: break-word;">{{ .ShortDescription }}</h2>
-      {{ if .LongDescription }}
-      <h4>{{ .LongDescription | MakeLinks }}</h4>
+      <h2 style="white-space: normal; word-wrap: break-word;">{{ .Title }}</h2>
+      {{ if .Description }}
+      <h4>{{ .Description | MakeLinks }}</h4>
       {{ end }}
 
       <br />


### PR DESCRIPTION
## What

For polls, rename the field `shortDescription` to `title`, and `longDescription` to `description`

## Why

The old names are kinda stupid and these make more sense

## Test Plan

Before updating all the data in Mongo, all the polls should have blank title and description.

Ensure all entries in mongo are updated correctly. Then, verify that all polls are showing the proper title and description

## Env Vars

no

## Checklist

- [X] Tested all changes locally
