### PR TITLE
Limited poll title character length to 250

### DIFF
--- a/api.go
+++ b/api.go
@@ -139,6 +139,12 @@ func CreatePoll(c *gin.Context) {
 		return
 	}
 
+	// If title length exceeds 250 characters, return a bad request
+	if len(c.PostForm("title")) > 250 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "title length exceeds limit of 250 characters"})
+		return
+	}
+
 	quorumType := c.PostForm("quorumType")
 
 	quorum, err := strconv.ParseFloat(quorumType, 64)

--- a/templates/create.tmpl
+++ b/templates/create.tmpl
@@ -9,7 +9,8 @@
             type="text"
             class="form-control"
             name="title"
-            placeholder="My Poll"
+            placeholder="My Poll (max 250 characters)"
+            maxlength="250"
             required
           >
         </div>


### PR DESCRIPTION
## What

The title for polls are now limited to 250 characters. 

## Why

To prevent polls with the bee movie script as their title.

## Test Plan

I tried to put the bee movie script as a poll title. It was capped to 250 characters.

## Env Vars

environment variables were not changed

## Documentation

Documentation was unchanged.

## Checklist

- [X ] Tested all changes locally
