### PR TITLE
fix: display ranked choice ballot errors inline (#117)

### DIFF
--- a/templates/poll.tmpl
+++ b/templates/poll.tmpl
@@ -81,8 +81,32 @@
         {{ end }}
       {{ end }}
         <br />
+        <div id="vote-error" class="alert alert-danger d-none" role="alert"></div>
         <button type="submit" class="btn btn-primary my-4 mx-4">Submit</button>
       </form>
+      <!-- Handle error messages -->
+      <script>
+        document.querySelector('form[action^="/poll/"]').addEventListener('submit', async function(e) {
+          e.preventDefault();
+          const form = e.target;
+          const errorEl = document.getElementById('vote-error');
+          errorEl.classList.add('d-none');
+
+          const res = await fetch(form.action, {
+            method: 'POST',
+            body: new FormData(form),
+          });
+
+          if (res.redirected) {
+            window.location.href = res.url;
+            return;
+          }
+
+          const data = await res.json();
+          errorEl.textContent = data.error ?? 'An unknown error occurred.';
+          errorEl.classList.remove('d-none');
+        });
+      </script>
       {{ if and (.CanModify) (not .Gatekeep) }}
         <form action="/poll/{{ .Id }}/close" method="POST">
           <button type="submit" class="btn btn-danger my-3 mx-4">End Poll</button>


### PR DESCRIPTION
## What

Added a JS script in `poll.tmpl` to handle JSON error response after `POST /poll/:id`.

## Why

To fix issue #117

## Test Plan

I created a html file based on the templates and simulated an error condition using the browser console. Verified script works as intended and error messsage is rendered correctly. 

## Env Vars

N/A

## Documentation

N/A

## Checklist

- [x] Tested all changes locally
